### PR TITLE
GraphTools::subgraphFromNodes: Add option to return a compact graph

### DIFF
--- a/include/networkit/graph/GraphTools.hpp
+++ b/include/networkit/graph/GraphTools.hpp
@@ -184,17 +184,80 @@ double inVolume(const Graph &G, InputIt first, InputIt last) {
 Graph copyNodes(const Graph &G);
 
 /**
- * Returns an induced subgraph of this graph (including potential edge weights/directions)
+ * Returns an induced subgraph of the input graph (including potential edge weights/directions)
  *
- * The subgraph contains all nodes in Nodes and all edges which have one end point
- * in Nodes and the other in Nodes.
+ * The subgraph contains all given nodes and all edges which have both end points in nodes.
  *
  * @param G The input graph.
- * @param nodes Nodes of the induced subgraph.
+ * @param nodes The nodes of the induced subgraph.
  *
  * @return Induced subgraph.
  */
 Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes);
+
+/**
+ * Returns an induced subgraph of the input graph (including potential edge weights/directions)
+ *
+ * The subgraph contains all nodes in the given node range and all edges which have both end points
+ * in nodes.
+ *
+ * @param G The input graph.
+ * @param first,last The range of nodes of the induced subgraph.
+ * @param compact If the resulting graph shall have compact, continuous node ids, alternatively,
+ * node ids of the input graph are kept.
+ *
+ * @return Induced subgraph.
+ */
+template <class InputIt>
+Graph subgraphFromNodes(const Graph &G, InputIt first, InputIt last, bool compact = false) {
+    count subgraphIdBound = 0;
+    std::unordered_map<node, node> reverseMapping;
+
+    if (compact) {
+        for (InputIt it = first; it != last; ++it) {
+            reverseMapping[*it] = subgraphIdBound;
+            ++subgraphIdBound;
+        }
+    } else {
+        subgraphIdBound = G.upperNodeIdBound();
+    }
+
+    Graph S(subgraphIdBound, G.isWeighted(), G.isDirected());
+
+    if (compact) {
+        for (auto nodeIt : reverseMapping) {
+            node u = nodeIt.first;
+            node localU = nodeIt.second;
+            G.forNeighborsOf(u, [&](node v, edgeweight weight) {
+                if (!G.isDirected() && u >= v)
+                    return;
+
+                auto vMapping = reverseMapping.find(v);
+                if (vMapping != reverseMapping.end())
+                    S.addEdge(localU, vMapping->second, weight);
+            });
+        }
+    } else {
+        // First, delete all nodes
+        for (node u = 0; u < G.upperNodeIdBound(); ++u) {
+            S.removeNode(u);
+        }
+
+        // Restore all given nodes
+        for (InputIt it = first; it != last; ++it) {
+            S.restoreNode(*it);
+        }
+
+        G.forEdges([&](node u, node v, edgeweight w) {
+            // only include edges if at least one endpoint is in nodes
+            if (S.hasNode(u) && S.hasNode(v)) {
+                S.addEdge(u, v, w);
+            }
+        });
+    }
+
+    return S;
+}
 
 /**
  * Returns an induced subgraph of this graph (including potential edge weights/directions)

--- a/networkit/cpp/components/ConnectedComponentsImpl.cpp
+++ b/networkit/cpp/components/ConnectedComponentsImpl.cpp
@@ -93,11 +93,7 @@ Graph ConnectedComponentsImpl<WeaklyCC>::extractLargestConnectedComponent(const 
             ->first;
 
     const auto nodesInLCC = component.getMembers(largestCCIndex);
-    const auto largestCC = GraphTools::subgraphFromNodes(G, {nodesInLCC.begin(), nodesInLCC.end()});
-    if (compactGraph)
-        return GraphTools::getCompactedGraph(largestCC,
-                                             GraphTools::getContinuousNodeIds(largestCC));
-    return largestCC;
+    return GraphTools::subgraphFromNodes(G, nodesInLCC.begin(), nodesInLCC.end(), compactGraph);
 }
 
 template class ConnectedComponentsImpl<false>;

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -135,7 +135,7 @@ Graph StronglyConnectedComponents::extractLargestStronglyConnectedComponent(cons
 
     const auto compSizes = component.subsetSizeMap();
     if (compSizes.size() == 1) {
-        if (compactGraph)
+        if (compactGraph && G.upperNodeIdBound() != G.numberOfNodes())
             return GraphTools::getCompactedGraph(G, GraphTools::getContinuousNodeIds(G));
         return G;
     }

--- a/networkit/cpp/components/StronglyConnectedComponents.cpp
+++ b/networkit/cpp/components/StronglyConnectedComponents.cpp
@@ -148,12 +148,7 @@ Graph StronglyConnectedComponents::extractLargestStronglyConnectedComponent(cons
                                      ->first;
 
     const auto nodesInLSCC = component.getMembers(largestSCCIndex);
-    const auto largestSCC =
-        GraphTools::subgraphFromNodes(G, {nodesInLSCC.begin(), nodesInLSCC.end()});
-    if (compactGraph)
-        return GraphTools::getCompactedGraph(largestSCC,
-                                             GraphTools::getContinuousNodeIds(largestSCC));
-    return largestSCC;
+    return GraphTools::subgraphFromNodes(G, nodesInLSCC.begin(), nodesInLSCC.end(), compactGraph);
 }
 
 } // namespace NetworKit

--- a/networkit/cpp/graph/GraphTools.cpp
+++ b/networkit/cpp/graph/GraphTools.cpp
@@ -220,25 +220,7 @@ Graph copyNodes(const Graph &G) {
 }
 
 Graph subgraphFromNodes(const Graph &G, const std::unordered_set<node> &nodes) {
-
-    auto isRelevantNode = [&](const node u) { return nodes.find(u) != nodes.end(); };
-
-    Graph S(G.upperNodeIdBound(), G.isWeighted(), G.isDirected());
-    // delete all nodes that are not in the node set
-    S.forNodes([&](node u) {
-        if (!isRelevantNode(u)) {
-            S.removeNode(u);
-        }
-    });
-
-    G.forEdges([&](node u, node v, edgeweight w) {
-        // only include edges if at least one endpoint is in nodes
-        if (isRelevantNode(u) && isRelevantNode(v)) {
-            S.addEdge(u, v, w);
-        }
-    });
-
-    return S;
+    return subgraphFromNodes(G, nodes.begin(), nodes.end(), false);
 }
 
 Graph subgraphFromNodesAndEdgesToTheirNeighbors(const Graph &G,

--- a/networkit/cpp/graph/test/GraphToolsGTest.cpp
+++ b/networkit/cpp/graph/test/GraphToolsGTest.cpp
@@ -647,9 +647,9 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
     G.addEdge(3, 2, 5.0);
     G.addEdge(1, 2, 3.0);
 
-    {
+    for (bool compact : std::array<bool, 2> {true, false}) {
         std::unordered_set<node> nodes = {0};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
         EXPECT_EQ(weighted(), res.isWeighted());
         EXPECT_FALSE(res.isDirected());
         EXPECT_EQ(res.numberOfNodes(), 1);
@@ -667,9 +667,9 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesUndirected) {
         EXPECT_DOUBLE_EQ(G.weight(0, 2), weighted() ? 2.0 : defaultEdgeWeight);
     }
 
-    {
+    for (bool compact : std::array<bool, 2> {true, false}) {
         std::unordered_set<node> nodes = {0, 1};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
         EXPECT_EQ(res.numberOfNodes(), 2);
         EXPECT_EQ(res.numberOfEdges(), 1); // 0 - 1
     }
@@ -699,15 +699,21 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
     G.addEdge(3, 2, 5.0);
     G.addEdge(1, 2, 3.0);
 
-    {
+    for (bool compact : std::array<bool, 2> {true, false}) {
         std::unordered_set<node> nodes = {0};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
 
         EXPECT_EQ(weighted(), res.isWeighted());
         EXPECT_TRUE(res.isDirected());
 
         EXPECT_EQ(res.numberOfNodes(), 1);
         EXPECT_EQ(res.numberOfEdges(), 0);
+
+        if (compact) {
+            EXPECT_EQ(res.upperNodeIdBound(), 1);
+        } else {
+            EXPECT_EQ(res.upperNodeIdBound(), G.upperNodeIdBound());
+        }
     }
 
     {
@@ -717,9 +723,9 @@ TEST_P(GraphToolsGTest, testSubgraphFromNodesDirected) {
         EXPECT_EQ(res.numberOfEdges(), 2); // 0->1, 0->2, NOT 1->2
     }
 
-    {
+    for (bool compact : std::array<bool, 2> {true, false}) {
         std::unordered_set<node> nodes = {0, 1};
-        auto res = GraphTools::subgraphFromNodes(G, nodes);
+        auto res = GraphTools::subgraphFromNodes(G, nodes.begin(), nodes.end(), compact);
         EXPECT_EQ(res.numberOfNodes(), 2);
         EXPECT_EQ(res.numberOfEdges(), 1); // 0 -> 1
     }

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -420,7 +420,7 @@ cdef class GraphTools:
 		return Graph().setThis(subgraphFromNodes(
 			graph._this, nodes))
 
-		@staticmethod
+	@staticmethod
 	def subgraphFromNodesAndEdgesToTheirNeighbors(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):
 		"""
 		Returns an induced subgraph of this graph (including potential edge

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -33,7 +33,7 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
 	_Graph toWeighted(_Graph G) nogil except +
-	_Graph subgraphFromNodes(_Graph G, unordered_set[node]) nogil except +
+	_Graph subgraphFromNodes[InputIt](_Graph G, InputIt first, InputIt last, bool_t compact) nogil except +
 	_Graph subgraphFromNodesAndEdgesToTheirNeighbors(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	void append(_Graph G, _Graph G1) nogil except +
 	void merge(_Graph G, _Graph G1) nogil except +
@@ -398,7 +398,7 @@ cdef class GraphTools:
 		return Graph().setThis(copyNodes(graph._this))
 
 	@staticmethod
-	def subgraphFromNodes(Graph graph, nodes):
+	def subgraphFromNodes(Graph graph, vector[node] nodes, bool_t compact = False):
 		"""
 		Returns an induced subgraph of this graph (including potential edge
 		weights/directions)
@@ -408,17 +408,19 @@ cdef class GraphTools:
 
 		Parameters:
 		-----------
-		graph : networkit.Graph
+		graph   : networkit.Graph
 			The input graph.
-		nodes : set
+		nodes   : iterable
 			Nodes in the induced subgraph.
+		compact : bool
+			If the resulting graph shall have compact, continuous node ids, alternatively, node ids of the input graph are kept.
 		Returns:
 		--------
 		graph : networkit.Graph
 			Induced subgraph.
 		"""
 		return Graph().setThis(subgraphFromNodes(
-			graph._this, nodes))
+			graph._this, nodes.begin(), nodes.end(), compact))
 
 	@staticmethod
 	def subgraphFromNodesAndEdgesToTheirNeighbors(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):

--- a/networkit/graphtools.pyx
+++ b/networkit/graphtools.pyx
@@ -33,7 +33,8 @@ cdef extern from "<networkit/graph/GraphTools.hpp>" namespace "NetworKit::GraphT
 	_Graph toUndirected(_Graph G) nogil except +
 	_Graph toUnweighted(_Graph G) nogil except +
 	_Graph toWeighted(_Graph G) nogil except +
-	_Graph subgraphFromNodes(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
+	_Graph subgraphFromNodes(_Graph G, unordered_set[node]) nogil except +
+	_Graph subgraphFromNodesAndEdgesToTheirNeighbors(_Graph G, unordered_set[node], bool_t, bool_t) nogil except +
 	void append(_Graph G, _Graph G1) nogil except +
 	void merge(_Graph G, _Graph G1) nogil except +
 	void removeEdgesFromIsolatedSet[InputIt](_Graph G, InputIt first, InputIt last) except +
@@ -397,7 +398,7 @@ cdef class GraphTools:
 		return Graph().setThis(copyNodes(graph._this))
 
 	@staticmethod
-	def subgraphFromNodes(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):
+	def subgraphFromNodes(Graph graph, nodes):
 		"""
 		Returns an induced subgraph of this graph (including potential edge
 		weights/directions)
@@ -417,7 +418,7 @@ cdef class GraphTools:
 			Induced subgraph.
 		"""
 		return Graph().setThis(subgraphFromNodes(
-			graph._this, nodes, includeOutNeighbors, includeInNeighbors))
+			graph._this, nodes))
 
 		@staticmethod
 	def subgraphFromNodesAndEdgesToTheirNeighbors(Graph graph, nodes, includeOutNeighbors=False, includeInNeighbors=False):
@@ -448,7 +449,7 @@ cdef class GraphTools:
 		graph : networkit.Graph
 			Induced subgraph.
 		"""
-		return Graph().setThis(subgraphFromNodes(
+		return Graph().setThis(subgraphFromNodesAndEdgesToTheirNeighbors(
 			graph._this, nodes, includeOutNeighbors, includeInNeighbors))
 
 	@staticmethod

--- a/networkit/test/test_graphtools.py
+++ b/networkit/test/test_graphtools.py
@@ -199,7 +199,7 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfNodes(), 1)
 		self.assertEqual(res.numberOfEdges(), 0)
 
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodesAndEdgesToTheirNeighbors(G, nodes, True)
 
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 2) # 0-1, 0-2, NOT 1-2
@@ -212,7 +212,7 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfNodes(), 2)
 		self.assertEqual(res.numberOfEdges(), 1) # 0 - 1
 
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodesAndEdgesToTheirNeighbors(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 4)
 		self.assertEqual(res.numberOfEdges(), 4) # 0-1, 0-2, 1-2, 1-3
 
@@ -229,7 +229,7 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfEdges(), 0)
 
 		nodes = set([0])
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodesAndEdgesToTheirNeighbors(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 2) # 0->1, 0->2, NOT 1->2
 
@@ -239,12 +239,12 @@ class TestGraphTools(unittest.TestCase):
 		self.assertEqual(res.numberOfEdges(), 1) # 0 -> 1
 
 		nodes = set([0, 1])
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True)
+		res = nk.graphtools.subgraphFromNodesAndEdgesToTheirNeighbors(G, nodes, True)
 		self.assertEqual(res.numberOfNodes(), 3)
 		self.assertEqual(res.numberOfEdges(), 3) # 0->1, 0->2, 1->2
 
 		nodes = set([0, 1])
-		res = nk.graphtools.subgraphFromNodes(G, nodes, True, True)
+		res = nk.graphtools.subgraphFromNodesAndEdgesToTheirNeighbors(G, nodes, True, True)
 		self.assertEqual(res.numberOfNodes(), 4)
 		self.assertEqual(res.numberOfEdges(), 4) # 0->1, 0->2, 1->2, 3->1
 


### PR DESCRIPTION
This adds a new variant of `GraphTools::subgraphFromNodes` that takes a range of nodes as input and can directly return a compact graph. I need this for networkit/networkit#448, to avoid later merge conflicts I suggest to include these changes in networkit/networkit#726.